### PR TITLE
App framework conformance tweaks

### DIFF
--- a/zowe_conformance/test_evaluation_guide.md
+++ b/zowe_conformance/test_evaluation_guide.md
@@ -192,7 +192,7 @@ These Zowe Conformant criteria are applicable to the lastest Zowe v1 LTS Release
 
     a. DOM elements originating from your App should always be children of the Zowe viewport DOM element, `com-rs-mvd-viewport`. **(required)**
 
-    b. Network requests to the Zowe App Server must never be done without the use of the URI Broker. **(required)**
+    b. Network requests to the Zowe App Server must never be done without the use of the URI Broker. This ensures compatibility with future versions of Zowe if URLs change. **(required)**
 
     c. Access to resources outside the App Server should also be made through the URI Broker whenever possible. **(best practice)**
 
@@ -207,7 +207,7 @@ These Zowe Conformant criteria are applicable to the lastest Zowe v1 LTS Release
 
 6.  **Localization and Internationalization (I10n and I18n)**
 
-    a. The active language to be used for string selection must be retrieved using ZoweZLUX.globalization.getLanguage(), which determines language by multiple factors. **(required)**
+    a. If your software supports multiple languages, the active language to be used for string selection must be retrieved using ZoweZLUX.globalization.getLanguage(), which determines language by multiple factors. **(required)**
 
     b. No strings visible in a UI should be hard-coded, rather resource strings must be used in accordance with one of the existing internationalization support mechanisms. **(best practice)**
 
@@ -239,7 +239,7 @@ These Zowe Conformant criteria are applicable to the lastest Zowe v1 LTS Release
 
 11. **Storage**
 
-    a. User preferences, if applicable to a plug-in, must be stored through the configuration data service. **(required)**
+    a. User preferences, if applicable to a plug-in, must be stored through the configuration data service, unless the software needs pre-existing storage structures such as DB2 **(required)**
 
     b. For other plug-in storage needs, storing data outside of the configuration dataservice is permitted only within `$INSTANCE_DIR/workspace/app-server` or `$INSTANCE_DIR/workspace/app-server/pluginStatic` with a top-level folder equal to their plug-in ID. Plug-ins must not store information anywhere else in any Zowe directories such as `$INSTANCE_DIR` or `$ROOT_DIR` in order to prevent conflict with future Zowe versions and other plug-ins. **(required)**
 
@@ -247,13 +247,13 @@ These Zowe Conformant criteria are applicable to the lastest Zowe v1 LTS Release
 
 12. **Directory and File Ownership Permissions**
 
-    a. A conformant application must not modify the contents of the Zowe runtime USS directory and must not change any directory or file permissions or ownership. **(required)**
+    a. A conformant application must not modify the contents of the Zowe root directory (`$ROOT_DIR`) and must not change any directory or file permissions or ownership. **(required)**
 
     b. A conformant application must not modify the permissions or ownership of a Zowe instance directory workspace. **(best practice)**
 
 13. **Lifecycling as a Zowe address space**
 
-    a. Satisfy the following criteria to lifecycle a service with Zowe:
+    a. If the app framework plugin requires services that do not originate from Zowe, but require the same lifecycle as Zowe, satisfy the following criteria to lifecycle them with Zowe:
     
      - Contain a fully qualified path in the `instance.env` file for the Zowe workspace which points to the location of a directory containing a `start.sh` script. **(required)**
      - Contain a validate.sh script. **(best practice)**

--- a/zowe_conformance/test_evaluation_guide_table.md
+++ b/zowe_conformance/test_evaluation_guide_table.md
@@ -885,7 +885,7 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
    <th style="background-color:#AAAAAA">x</th>
    <th style="background-color:#AAAAAA"></th>
    <th></th>
-   <td>Network requests to the Zowe App Server must never be done without the use of the URI Broker</td>
+   <td>Network requests to the Zowe App Server must never be done without the use of the URI Broker. This ensures compatibility with future versions of Zowe if URLs change.</td>
  </tr>
   <tr>
    <th style="background-color:#555555">11</th>
@@ -961,7 +961,7 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
    <th style="background-color:#AAAAAA">x</th>
    <th style="background-color:#AAAAAA"></th>
    <th></th>
-   <td>The active language to be used for string selection must be retrieved using ZoweZLUX.globalization.getLanguage(), which determines language by multiple factors</td>
+   <td>If your software supports multiple languages, the active language to be used for string selection must be retrieved using ZoweZLUX.globalization.getLanguage(), which determines language by multiple factors</td>
  </tr>
   <tr>
    <th style="background-color:#555555">17</th>
@@ -1120,7 +1120,7 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
    <th style="background-color:#AAAAAA">x</th>
    <th style="background-color:#AAAAAA"></th>
    <th></th>
-   <td>User preferences, if applicable to a plugin, must be stored through the configuration data service </td>
+   <td>User preferences, if applicable to a plug-in, must be stored through the configuration data service, unless the software needs pre-existing storage structures such as DB2 </td>
  </tr>
  <tr>
    <th style="background-color:#555555">28</th>
@@ -1158,7 +1158,7 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
    <th style="background-color:#AAAAAA">x</th>
    <th style="background-color:#AAAAAA"></th>
    <th></th>
-   <td>A conformant application must not modify the contents of the Zowe runtime USS directory and must not change any directory or file permissions or ownership </td>
+   <td>A conformant application must not modify the contents of the Zowe root directory <code>$ROOT_DIR</code> and must not change any directory or file permissions or ownership </td>
  </tr>
  <tr>
    <th style="background-color:#555555">31</th>
@@ -1186,7 +1186,7 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
    <th rowspan=4 style="background-color:#555555">32</th>
    <th style="background-color:#555555"></th>
    <th colspan ="3" style="background-color:#AAAAAA">Applicable if LIFECYCLED</th>
-   <td>Satisfy the following criteria to lifecycle a service with Zowe:</td>
+   <td>If the app framework plugin requires services that do not originate from Zowe, but require the same lifecycle as Zowe, satisfy the following criteria to lifecycle them with Zowe:</td>
  </tr>
  <tr>
 


### PR DESCRIPTION
Update app framework conformance criteria with clarifications and conditions based on vendor feedback

1. we used to have a clause about not needing our storage mechanism of you already have one, but it got omitted somehow

2. we shouldnt require multiple languages, since thats a customer ask, so i clarified that we only need that language preference detection is unified

3. added a bit of info as to why people should be using the uri broker. This level of detail may not be needed?

4. clarified that "runtime directory" really meant $ROOT_DIR

5. I found that the component requirements & best practices are in the app framework section. This isn't totally correct, but I tried to clarify the purpose behind when you would need to follow our lifecycling scheme, so that people don't suddenly think DB2 needs to support zowe's scheme.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>