### PR TITLE
Revising tagging conformance criteria for correctness

### DIFF
--- a/zowe_conformance/test_evaluation_guide.md
+++ b/zowe_conformance/test_evaluation_guide.md
@@ -233,7 +233,7 @@ These Zowe Conformant criteria are applicable to the lastest Zowe v1 LTS Release
     
 10. **Encoding**
 
-    a. To enable an App to work with z/OS Node.js version 12 or higher, all application files must be tagged according to their content type. **(required)**
+    a. Application Framework plugins serving web content through App Server or doing file I/O through an App Server dataservice should tag these files on z/OS according to their content type. **(best practice)**
     
     b. Testing Apps via the install-app script is advisable to enable end users to utilize Zowe plugin management tooling. **(best practice)**
 

--- a/zowe_conformance/test_evaluation_guide_table.md
+++ b/zowe_conformance/test_evaluation_guide_table.md
@@ -1087,10 +1087,10 @@ These Zowe Conformance criteria are applicable to the lastest Zowe v1 LTS Releas
  <tr>
    <th style="background-color:#555555">25</th>
    <th style="background-color:#555555">v1</th>
-   <th style="background-color:#AAAAAA">x</th>
    <th style="background-color:#AAAAAA"></th>
+   <th style="background-color:#AAAAAA">x</th>
    <th></th>
-   <td>To enable an App to work with z/OS Node.js version 12 or higher, all application files must be tagged according to their content type</td>
+   <td>Application Framework plugins serving web content through App Server or doing file I/O through an App Server dataservice should tag these files on z/OS according to their content type</td>
  </tr>
  <tr>
    <th style="background-color:#555555">26</th>


### PR DESCRIPTION
The original draft of the conformance did not require tagging of files, but somehow it became a requirement on paper. 

Tagging is a really good idea, but it's not actually a requirement of the code on any version of nodeJS because Zowe uses a configuration option by which nodeJS 12+ treats untagged file encoding identical to versions before 12. IBM has stated this option will continue to exist and there's no end in sight for it, so there isn't a reason to force tagging at this time.

Furthermore, there are some technical hurdles around tagging files at runtime. It's pretty easy to tag what you ship, but if files are created at runtime, how they get tagged is implementation-specific and nodejs doesn't have a built-in way to do it, for example.

So for now, this should be marked as a best practice.
If the nodejs flag we use for having consistent untagged behavior ever becomes deprecated, we'll switch this to being a requirement, but there is no date on that happening.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>