### PR TITLE
Allow hyphen in service id for API Mediation Layer and limit to 63 characacters

### DIFF
--- a/zowe_conformance/test_evaluation_guide_table.md
+++ b/zowe_conformance/test_evaluation_guide_table.md
@@ -466,7 +466,7 @@ Plug-in documentation should identify the possible values that may be returned b
 <td style="background-color: #AAAAAA"><center>x</center></td>
 <td style="background-color: #AAAAAA"></td>
 <td></td>
-<td >The service ID must be written in lower case, contain no symbols, and is limited to 64 characters</td>
+<td >The service ID must be written in lower case, contain no symbols other than hyphen, and is limited to 63 characters</td>
 </tr>
 <tr>
 <td style="background-color: #555555">6</td>


### PR DESCRIPTION
The reason for the change to 63 characters is technical. The 64 characters won't actually work. Nobody is providing such service id at the moment. 

The allowing of hyphen is to make the possibility of more human readable URLs. 

The discussion on the topic happened on Zowe TSC on October 17th, 2024 and it was accepted by the whole body. 